### PR TITLE
ties_md removed, relaxed numpy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,7 @@ channels:
 
 dependencies:
   - conda-forge::ambertools >=21.0
-  - ties_md
-  - numpy==1.23.5 # fixme? 
+  - numpy
   - cython
   - setuptools
   - matplotlib


### PR DESCRIPTION
Simplify the ties_md. TIES_MD should be used from withing TIES_MD and should call TIES when needed using the API. 