### PR TITLE
Tolerating empty suptops and returning None in that case.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
  * fixes:
   * restricting the atom names to 4 characters
 
- * version 22.6.0:
-  * transitioned all MDAnalysis features to parmed and pyqtprot
-  * embedded pyqtprot into ties20
+
+ * version 2.*.*:
+  * ignoring empty suptops and returning
+  None if nothing can be created (#PR343)
+
+ * version 2.1.0:
+  * transitioned to MDAnalysis for superimposition

--- a/ties/cli.py
+++ b/ties/cli.py
@@ -200,6 +200,9 @@ def command_line_script():
 
         hybrid = pair.superimpose()
 
+        if hybrid is None:
+            continue
+
         # save metadata
         hybrid.write_metadata()
         hybrid.write_pdb()
@@ -220,6 +223,9 @@ def command_line_script():
     ##########################################################
     # ------------------   Ligand ----------------------------
     for pair in selected_pairs:
+        if pair.suptop is None:
+            continue
+
         pair.suptop.prepare_inputs(protein=None)
         print(f'Ligand {pair} directory populated successfully')
 

--- a/ties/pair.py
+++ b/ties/pair.py
@@ -178,9 +178,11 @@ class Pair():
 
         self.set_suptop(suptop, parmed_ligA, parmed_ligZ)
         # attach the used config to the suptop
-        suptop.config = self.config
-        # attach the morph to the suptop
-        suptop.morph = self
+
+        if suptop is not None:
+            suptop.config = self.config
+            # attach the morph to the suptop
+            suptop.morph = self
 
         return suptop
 

--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -14,6 +14,7 @@ import logging
 import subprocess
 import pathlib
 import re
+import warnings
 from typing import Dict, List, Set, Tuple
 from functools import reduce
 from collections import OrderedDict
@@ -3195,8 +3196,8 @@ def superimpose_topologies(top1_nodes,
                                       starting_pair_seed=starting_pair_seed,
                                       weights=weights)
     if not suptops:
-        raise Exception('Error: Did not find a single superimposition state.'
-                        'Error: Not even a single atom is common across the two molecules? Something must be wrong. ')
+        warnings.warn('Did not find a single superimposition state.')
+        return None
 
     print(f'Phase 1: The number of SupTops found: {len(suptops)}')
     print(f'SupTops lengths:  {", ".join([f"ST{st.id}: {len(st)}" for st in suptops])}')
@@ -3419,7 +3420,9 @@ def extract_best_suptop(suptops, ignore_coords, weights=[1, 1], get_list=False):
             return suptops[0]
 
     if len(suptops) == 0:
-        raise Exception('Cannot decide on the best mapping without any suptops...')
+        warnings.warn('Cannot decide on the best mapping without any suptops...')
+        return None
+
     elif len(suptops) == 1:
         return item_or_list(suptops)
 


### PR DESCRIPTION
This is not an ideal solution. In theory we should have the lowest scores for this kind of suptops. However, we would not want to check any None values.

Changed A to .. 

#### Todos
 - [ ] Updated version.txt
 - [x] Updated the changelog
 - [ ] Added test cases
