### PR TITLE
Empty suptops

### DIFF
--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -1406,7 +1406,11 @@ class SuperimposedTopology:
         # get pairs with different charges
         diff_q_pairs = self.get_matched_with_diff_q()
         if len(diff_q_pairs) == 0:
-            raise Exception('Did not find any pairs with a different q even though the net tol is not met? ')
+            warnings.warn('No pairs with different partial charges, '
+                          'even though the net tol is not met. '
+                          'Ignoring this transformation (workaround). ')
+            # fixme - this is a simple workaround
+            return [self.matched_pairs[0], ]
 
         # sort the pairs into categories
         # use 5 pairs with the largest difference

--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -3353,6 +3353,9 @@ def superimpose_topologies(top1_nodes,
         #
         # assert len(suptops) == 1, suptops
 
+    if len(suptops) == 0:
+        return None
+
     suptop = extract_best_suptop(suptops, ignore_coords, get_list=False)
 
     if redistribute_charges_over_unmatched and not ignore_charges_completely:


### PR DESCRIPTION
This is another rare case where a few suptops make it to the end just to be emptied due to poor charges and other heuristics. 

Here we simply ignore the bad pairings and return None to indicate that. 