### PR TITLE
Non-unique atom named creating issue for NAMD tagings (B-factor for alchemical transformation)

### DIFF
--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -517,7 +517,7 @@ class SuperimposedTopology:
 
         # generate the merged fep file
         complex_solvated_fep = build / 'complex.pdb'
-        ties.generator.correct_fep_tempfactor(self.morph.suptop.toJSON(), hybrid_solv, complex_solvated_fep,
+        ties.generator.correct_fep_tempfactor(self.morph.suptop, hybrid_solv, complex_solvated_fep,
                                hybrid_topology=self.config.use_hybrid_single_dual_top)
 
         # fixme - check that the protein does not have the same resname?


### PR DESCRIPTION
…PDB tags (B-factor -1 and 1) for NAMD.

Specifically, we previously used unique atom names for .MOL2 and .PDB. This means that we could always go back and combine the summary JSON with any of them to recover which atoms were appearing and disappearing. Well, that's not the case anymore, and ideally the JSON should be updated too. Here we simply use indices to recover the original atoms.

Changed A to .. 

#### Todos
 - [ ] Updated version.txt
 - [ ] Updated the changelog
 - [ ] Added test cases
