### PR TITLE
MCS and RMSD weights in CLI

### DIFF
--- a/ties/cli.py
+++ b/ties/cli.py
@@ -143,7 +143,7 @@ def command_line_script():
                         type=ArgparseChecker.str2bool, required=False, default=False,
                         help='Ignore the specific atom types in the superimposition. Use only the elements. ')
     parser.add_argument('-weights', '--mcs-rmsd-weights', metavar='str', dest='weights_ratio',
-                        type=ArgparseChecker.ratio, required=False,
+                        type=ArgparseChecker.ratio, required=False, default='1:0.05',
                         help='The weights for the weighted sum of 1) MCS overlap size to 2) RMSD '
                              'when coordinates are used for selection of the best structure. '
                              'Default it is "1:1" for "MCS:RMSD".  '

--- a/ties/config.py
+++ b/ties/config.py
@@ -53,7 +53,7 @@ class Config:
         self._use_element_in_superimposition = True
         self.starting_pairs_heuristics = True
         # weights in choosing the best MCS, the weighted sum of "(1 - MCS fraction) and RMSD".
-        self.weights = [1, 0.5]
+        self.weights_ratio = [1, 0]
 
         # coordinates
         self._align_molecules_using_mcs = False
@@ -572,9 +572,6 @@ class Config:
             return
         if self._ligand_files is None:
             raise ValueError('Wrong use of Config class. Please set the ._ligand_files attribute first. ')
-        elif len(self._ligand_files) != 2:
-            raise ValueError('Error: Too many ligands. '
-                             'Manually matching atom pairs works only with 2 ligands. ')
 
         # TODO
         # pair_format: C1-C7 or C1-C7,C2-C8

--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -2971,7 +2971,7 @@ def solve_one_combination(one_atom_species, ignore_coords):
 
 
 def _overlay(n1, n2, parent_n1, parent_n2, bond_types, suptop, ignore_coords=False, use_element_type=True,
-             exact_coords_cue=False):
+             exact_coords_cue=False, weights=(1, 0.01)):
     """
     Jointly and recursively traverse the molecule while building up the suptop.
 
@@ -3111,7 +3111,8 @@ def _overlay(n1, n2, parent_n1, parent_n2, bond_types, suptop, ignore_coords=Fal
                                   suptop=suptop,
                                   ignore_coords=ignore_coords,
                                   use_element_type=use_element_type,
-                                  exact_coords_cue=exact_coords_cue)
+                                  exact_coords_cue=exact_coords_cue,
+                                  weights=weights)
 
         if larger_suptop is not None:
             larger_suptops.append(larger_suptop)
@@ -3143,7 +3144,7 @@ def _overlay(n1, n2, parent_n1, parent_n2, bond_types, suptop, ignore_coords=Fal
             if sol2 in all_solutions:
                 all_solutions.remove(sol2)
 
-    best_suptop = extract_best_suptop(all_solutions, ignore_coords)
+    best_suptop = extract_best_suptop(all_solutions, ignore_coords, weights=weights)
     return best_suptop
 
 
@@ -3199,7 +3200,7 @@ def superimpose_topologies(top1_nodes,
     if config is None:
         weights = [1, 1]
     else:
-        weights = config.weights
+        weights = config.weights_ratio
 
     # Get the superimposed topology(/ies).
     suptops = _superimpose_topologies(top1_nodes, top2_nodes, parmed_ligA, parmed_ligZ,
@@ -3780,7 +3781,8 @@ def _superimpose_topologies(top1_nodes, top2_nodes, mda1_nodes=None, mda2_nodes=
         candidate_suptop = _overlay(node1, node2, parent_n1=None, parent_n2=None, bond_types=(None, None),
                                     suptop=suptop,
                                     ignore_coords=ignore_coords,
-                                    use_element_type=use_general_type)
+                                    use_element_type=use_general_type,
+                                    weights=weights)
         if candidate_suptop is None:
             # there is no overlap, ignore this case
             continue


### PR DESCRIPTION
Added weights to be able to steer superimpositions from the CLI. E.g. ties -l 0.mol2 9994.mol2 -weights "1:0"