### PR TITLE
By default, ignore RMSD in the scoring of overlaps.

### DIFF
--- a/ties/cli.py
+++ b/ties/cli.py
@@ -143,7 +143,7 @@ def command_line_script():
                         type=ArgparseChecker.str2bool, required=False, default=False,
                         help='Ignore the specific atom types in the superimposition. Use only the elements. ')
     parser.add_argument('-weights', '--mcs-rmsd-weights', metavar='str', dest='weights_ratio',
-                        type=ArgparseChecker.ratio, required=False, default='1:0.05',
+                        type=ArgparseChecker.ratio, required=False, default='1:0.00',
                         help='The weights for the weighted sum of 1) MCS overlap size to 2) RMSD '
                              'when coordinates are used for selection of the best structure. '
                              'Default it is "1:1" for "MCS:RMSD".  '


### PR DESCRIPTION
When ligands are not well aligned and have very different shapes, the RMSD can significantly affect their weight of the final score. 

This happens due to the fact that we do not normalise RMSD. Meaning that they can be large in comparison to the overlap (which is between 0 and 1). 

@shunzhou 