### PR TITLE
One H was missing from the solution - due to different defaults (coor…

### DIFF
--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -3761,7 +3761,7 @@ def _superimpose_topologies(top1_nodes, top2_nodes, mda1_nodes=None, mda2_nodes=
                             use_general_type=True,
                             starting_pairs_heuristics: float = 0,
                             starting_pair_seed=None,
-                            weights=[1, 1]):
+                            weights=[1, 0]):
     """
     Superimpose two molecules.
 


### PR DESCRIPTION
…dinates were being used).

Changed A to .. 

#### Todos
 - [ ] Updated version.txt
 - [ ] Updated the changelog
 - [ ] Added test cases
