### PR TITLE
Feature: allow setting multiple starting pairs in CLI.

### DIFF
--- a/ties/cli.py
+++ b/ties/cli.py
@@ -79,13 +79,13 @@ def command_line_script():
                         help='A path to a file that contains atom-pairs (one per line).'
                              'Each pair should be separated by dash "-" character.'
                              'For example a line with CL2-BR2 means that CL2 atom will be transformed to BR2 atom.')
-    parser.add_argument('-supseed', '--superimposition-starting-pair', metavar='pair',
-                        dest='superimposition_starting_pair',
+    parser.add_argument('-seeds', '--superimposition-starting-pairs', metavar='pairs',
+                        dest='superimposition_starting_pairs',
                         type=str, required=False,
                         help='A starting seed for the superimposition. '
-                             'This is the pair from which the superimposition algorithm will start the '
+                             'The semi-colon delimited pairs from which the superimposition algorithm will start the '
                              'traversal to find the superimposition. '
-                             'Example: "C1-C34" where C1 is in the disappearing molecule, '
+                             'Example with 2 pairs: "C1-C34;C2-C35" where C1 is in the disappearing molecule, '
                              'and C34 is in the appearing molecule. ')
     parser.add_argument('-heuristic', '--superimposition-starting-heuristic', metavar='number',
                         dest='superimposition_starting_heuristic',

--- a/ties/config.py
+++ b/ties/config.py
@@ -70,7 +70,7 @@ class Config:
         self._ligand_tleap_in = None
         self._complex_tleap_in = None
 
-        self._superimposition_starting_pair = None
+        self._superimposition_starting_pairs = None
         self._superimposition_starting_heuristic = 0
 
         self._protein_ff = None
@@ -539,22 +539,25 @@ class Config:
         self._ligands_contain_q = boolean
 
     @property
-    def superimposition_starting_pair(self):
+    def superimposition_starting_pairs(self):
         """
         Set a starting pair for the superimposition to narrow down the MCS search.
         E.g. "C2-C12"
 
         :rtype: str
         """
-        return self._superimposition_starting_pair
+        return self._superimposition_starting_pairs
 
-    @superimposition_starting_pair.setter
-    def superimposition_starting_pair(self, value):
+    @superimposition_starting_pairs.setter
+    def superimposition_starting_pairs(self, value):
+
         if value == None:
-            self._superimposition_starting_pair = None
-        else:
-            atom_name_disappearing, atom_name_appearing = value.split('-')
-            self. _superimposition_starting_pair = (atom_name_disappearing, atom_name_appearing)
+            self._superimposition_starting_pairs = None
+            return
+
+        # split the different starting pairs
+        pairs = value.split(";")
+        self. _superimposition_starting_pairs = [pair.split("-") for pair in pairs]
 
     @property
     def superimposition_starting_heuristic(self):

--- a/ties/pair.py
+++ b/ties/pair.py
@@ -162,26 +162,26 @@ class Pair():
 
         # fixme - simplify to only take the ParmEd as input
         suptop = superimpose_topologies(ligand1_nodes.values(), ligand2_nodes.values(),
-                                         disjoint_components=self.config.allow_disjoint_components,
-                                         net_charge_filter=True,
-                                         pair_charge_atol=self.config.atom_pair_q_atol,
-                                         net_charge_threshold=self.config.net_charge_threshold,
-                                         redistribute_charges_over_unmatched=self.config.redistribute_q_over_unmatched,
-                                         ignore_charges_completely=self.config.ignore_charges_completely,
-                                         ignore_bond_types=True,
-                                         ignore_coords=False,
-                                         align_molecules=self.config.align_molecules_using_mcs,
-                                         use_general_type=self.config.use_element_in_superimposition,
-                                         # fixme - not the same ... use_element_in_superimposition,
-                                         use_only_element=False,
-                                         check_atom_names_unique=True,  # fixme - remove?
-                                         starting_pairs_heuristics=self.config.superimposition_starting_heuristic,  # fixme - add to config
-                                         force_mismatch=new_mismatch_names,
-                                         starting_node_pairs=starting_node_pairs,
-                                         parmed_ligA=parmed_ligA, parmed_ligZ=parmed_ligZ,
-                                         starting_pair_seed=self.config.superimposition_starting_pair,
-                                         logging_key=logging_key,
-                                         config=self.config)
+                                        disjoint_components=self.config.allow_disjoint_components,
+                                        net_charge_filter=True,
+                                        pair_charge_atol=self.config.atom_pair_q_atol,
+                                        net_charge_threshold=self.config.net_charge_threshold,
+                                        redistribute_charges_over_unmatched=self.config.redistribute_q_over_unmatched,
+                                        ignore_charges_completely=self.config.ignore_charges_completely,
+                                        ignore_bond_types=True,
+                                        ignore_coords=False,
+                                        align_molecules=self.config.align_molecules_using_mcs,
+                                        use_general_type=self.config.use_element_in_superimposition,
+                                        # fixme - not the same ... use_element_in_superimposition,
+                                        use_only_element=False,
+                                        check_atom_names_unique=True,  # fixme - remove?
+                                        starting_pairs_heuristics=self.config.superimposition_starting_heuristic,  # fixme - add to config
+                                        force_mismatch=new_mismatch_names,
+                                        starting_node_pairs=starting_node_pairs,
+                                        parmed_ligA=parmed_ligA, parmed_ligZ=parmed_ligZ,
+                                        starting_pair_seed=self.config.superimposition_starting_pairs,
+                                        logging_key=logging_key,
+                                        config=self.config)
 
         self.set_suptop(suptop, parmed_ligA, parmed_ligZ)
         # attach the used config to the suptop

--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -3225,7 +3225,7 @@ def superimpose_topologies(top1_nodes,
                                       ignore_coords=ignore_coords,
                                       use_general_type=use_general_type,
                                       starting_pairs_heuristics=starting_pairs_heuristics,
-                                      starting_pair_seed=starting_pair_seed,
+                                      starting_pairs=starting_pair_seed,
                                       weights=weights)
     if not suptops:
         warnings.warn('Did not find a single superimposition state.')
@@ -3760,7 +3760,7 @@ def _superimpose_topologies(top1_nodes, top2_nodes, mda1_nodes=None, mda2_nodes=
                             ignore_coords=False,
                             use_general_type=True,
                             starting_pairs_heuristics: float = 0,
-                            starting_pair_seed=None,
+                            starting_pairs=None,
                             weights=[1, 0]):
     """
     Superimpose two molecules.
@@ -3781,17 +3781,21 @@ def _superimpose_topologies(top1_nodes, top2_nodes, mda1_nodes=None, mda2_nodes=
     #   pick a starting point from each component
     if starting_node_pairs is None or len(starting_node_pairs) == 0:
         # generate each to each nodes
-        if starting_pair_seed:
-            left_atom = [a for a in list(top1_nodes) if a.name == starting_pair_seed[0]][0]
-            right_atom = [a for a in list(top2_nodes) if a.name == starting_pair_seed[1]][0]
-            starting_node_pairs = [(left_atom, right_atom), ]
+        if starting_pairs:
+            starting_node_pairs = []
+            for dis_atom, app_atom in starting_pairs:
+                left_atom = [a for a in list(top1_nodes) if a.name == dis_atom][0]
+                right_atom = [a for a in list(top2_nodes) if a.name == app_atom][0]
+                starting_node_pairs.append((left_atom, right_atom))
         elif starting_pairs_heuristics == 0:
             logger.debug('Heuristics is off. All pairs will be searched. ')
             starting_node_pairs = list(itertools.product(top1_nodes, top2_nodes))
         else:
             starting_node_pairs = get_starting_configurations(top1_nodes, top2_nodes, fraction=starting_pairs_heuristics)
             logger.debug('Using heuristics to select the initial pairs for searching the maximum overlap.'
-                  f'Could produce non-optimal results. Using pairs: {starting_node_pairs}')
+                  f'Could produce non-optimal results. ')
+
+    logger.debug(f"Seed Pairs: {starting_node_pairs}")
 
     for node1, node2 in starting_node_pairs:
         # with the given starting two nodes, generate the maximum common component


### PR DESCRIPTION
Allowing setting multiple starting points for the superimposition: `-seeds "C1-C15;O1-O3"`  

This means that we now have "-seeds" instead of "-supseed". 

This is useful for debugging. 