### PR TITLE
Fix propagating weights everywhere

### DIFF
--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -2521,9 +2521,7 @@ class SuperimposedTopology:
 
     def report_differences(self, suptop):
         self_has_not_suptop = self.has_in_contrast_to(suptop)
-        log("self has not suptop:", self_has_not_suptop)
         suptop_has_not_self = suptop.has_in_contrast_to(self)
-        log('Suptop has not self', suptop_has_not_self)
         return self_has_not_suptop, suptop_has_not_self
 
     def has_left_nodes_same_as(self, other):
@@ -2731,17 +2729,14 @@ def long_merge(suptop1, suptop2):
         return suptop1
 
     if suptop1.eq(suptop2):
-        log("Merge: the two are the equal. Ignoring")
         return suptop1
 
     if suptop2.is_subgraph_of(suptop1):
-        log("Merge: this is already a superset. Ignoring")
         return suptop1
 
     # check if the two are consistent
     # ie there is no clashes
     if not suptop1.is_consistent_with(suptop2):
-        log("Merge: cannot merge - not consistent")
         return -1
 
     # fixme - this can be removed because it is now taken care of in the other functions?
@@ -2900,7 +2895,6 @@ def solve_one_combination(one_atom_species, ignore_coords):
             for name in keys.keys():
                 unique_atoms.add(name)
         if len(unique_atoms) == 1:
-            log('Many (left) to one (right)')
             # just pick the best match fro the right ligand
             candidates = [list(v.values())[0] for v in atoms.values()]
             largest_candidates = get_largest(candidates)

--- a/ties/topology_superimposer.py
+++ b/ties/topology_superimposer.py
@@ -3372,7 +3372,7 @@ def superimpose_topologies(top1_nodes,
     if len(suptops) == 0:
         return None
 
-    suptop = extract_best_suptop(suptops, ignore_coords, get_list=False)
+    suptop = extract_best_suptop(suptops, ignore_coords, weights=weights, get_list=False)
 
     if redistribute_charges_over_unmatched and not ignore_charges_completely:
         # assume that none of the suptops are disjointed
@@ -3422,7 +3422,7 @@ def calculate_rmsd(atom_pairs):
     return np.sqrt(np.mean(((np.array(deviations)) ** 2)))
 
 
-def extract_best_suptop(suptops, ignore_coords, weights=[1, 1], get_list=False):
+def extract_best_suptop(suptops, ignore_coords, weights, get_list=False):
     """
     Assumes that any merging possible already took place.
     We now have a set of solutions and have to select the best ones.
@@ -3552,9 +3552,11 @@ def exists_in(candidate_suptop, suptops):
     return False
 
 
-def is_mirror_of_one(candidate_suptop, suptops, ignore_coords):
+def is_mirror_of_one(candidate_suptop, suptops, ignore_coords, extract_weight_ratio):
     """
     "Mirror" in the sense that it is an alternative topological way to traverse the molecule.
+
+    extract_weight_ratio: refers to the extract_best_suptop function parameter
 
     Depending on the "better" fit between the two mirrors, we pick the one that is better.
     """
@@ -3562,7 +3564,7 @@ def is_mirror_of_one(candidate_suptop, suptops, ignore_coords):
         if next_suptop.is_mirror_of(candidate_suptop):
             # the suptop saved as the mirror should be the suptop
             # that is judged to be of a lower quality
-            best_suptop = extract_best_suptop([candidate_suptop, next_suptop], ignore_coords)
+            best_suptop = extract_best_suptop([candidate_suptop, next_suptop], ignore_coords, weights=extract_weight_ratio)
 
             if next_suptop is best_suptop:
                 next_suptop.add_mirror_suptop(candidate_suptop)
@@ -3818,7 +3820,7 @@ def _superimpose_topologies(top1_nodes, top2_nodes, mda1_nodes=None, mda2_nodes=
         # check if this superimposed topology is a mirror of one that already exists
         # fixme the order matters in this place
         # fixme - what if the mirror has a lower rmsd match? in that case, pick that mirror here
-        if is_mirror_of_one(candidate_suptop, suptops, ignore_coords):
+        if is_mirror_of_one(candidate_suptop, suptops, ignore_coords, weights):
             continue
 
         #


### PR DESCRIPTION
The weights [1, 1] were being used at one point leading to issues. Specifically, sometimes there is just one atom meaning that it will have a perfect RMSD. Therefore it scores the maximum. This meant that it was beating the optimal solutions. This was due to the large alchemical regions. 