### PR TITLE
When suptops have the same length, select one with lower RMSD.

### DIFF
--- a/ties/cli.py
+++ b/ties/cli.py
@@ -350,7 +350,7 @@ def command_line_script():
         dest="weights_ratio",
         type=ArgparseChecker.ratio,
         required=False,
-        default="1:0.00",
+        default=None,
         help="The weights for the weighted sum of 1) MCS overlap size to 2) RMSD "
         "when coordinates are used for selection of the best structure. "
         'Default it is "1:0" for "MCS:RMSD".  '

--- a/ties/cli.py
+++ b/ties/cli.py
@@ -24,7 +24,9 @@ logger = logging.getLogger(__name__)
 
 
 def command_line_script():
-    parser = argparse.ArgumentParser(description="TIES 20")
+    parser = argparse.ArgumentParser(
+        description="TIES 20", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument(
         "-action",
         "--action",

--- a/ties/config.py
+++ b/ties/config.py
@@ -54,10 +54,10 @@ class Config:
         self._use_rdkit_mcs = False
         self._use_element_in_superimposition = True
         self._partial_ring_allowed = False
-        self._ignore_coords = False
+        self._use_rmsd = True
         self.starting_pairs_heuristics = True
         # weights in choosing the best MCS, the weighted sum of "(1 - MCS fraction) and RMSD".
-        self.weights_ratio = [1, 0]
+        self.weights_ratio = None  # [1, 0]
 
         # coordinates
         self._align_molecules_using_mcs = False
@@ -475,8 +475,14 @@ class Config:
         return self._partial_ring_allowed
 
     @property
-    def ignore_coords(self):
-        return self._ignore_coords
+    def use_rmsd(self):
+        """
+        Whether to use the RMSD to decide which solution is better.
+        If two solutions are of the same length, the RMSD will be the decider.
+
+        The RMSD is calculated only for the joint part.
+        """
+        return self._use_rmsd
 
     @property
     def align_molecules_using_mcs(self):

--- a/ties/config.py
+++ b/ties/config.py
@@ -54,6 +54,7 @@ class Config:
         self._use_rdkit_mcs = False
         self._use_element_in_superimposition = True
         self._partial_ring_allowed = False
+        self._ignore_coords = False
         self.starting_pairs_heuristics = True
         # weights in choosing the best MCS, the weighted sum of "(1 - MCS fraction) and RMSD".
         self.weights_ratio = [1, 0]
@@ -472,6 +473,10 @@ class Config:
     @property
     def partial_ring_allowed(self):
         return self._partial_ring_allowed
+
+    @property
+    def ignore_coords(self):
+        return self._ignore_coords
 
     @property
     def align_molecules_using_mcs(self):

--- a/ties/overlay.py
+++ b/ties/overlay.py
@@ -274,28 +274,21 @@ def merge_compatible_suptops_faster(pairing_suptop: dict, min_bonds: int):
     return built_topologies
 
 
-def extract_best_suptop(suptops, ignore_coords, weights, get_list=False):
+def extract_best_suptop(
+    suptops, ignore_coords, weights, use_combined_score=False, get_list=False
+):
     """
     Assumes that any merging possible already took place.
     We now have a set of solutions and have to select the best ones.
 
     :param suptops:
-    :param ignore_coords:
+    :param ignore_coords: Do not use coordinates at all. This means a very simple selection
+        based purely on the MCS size.
+    :param use_combined_score: Whether to use a combined score (MCS size with RMSD) for an
+        automated selection. Note this feature was causing tricky issues.
     :return:
     """
 
-    # fixme - ignore coords currently does not work
-    # multiple different paths to traverse the topologies were found
-    # this means some kind of symmetry in the topologies
-    # For example, in the below drawn case (starting from C1-C11) there are two
-    # solutions: (O1-O11, O2-O12) and (O1-O12, O2-O11).
-    #     LIGAND 1        LIGAND 2
-    #        C1              C11
-    #        \                \
-    #        N1              N11
-    #        /\              / \
-    #     O1    O2        O11   O12
-    # Here we decide which of the mappings is better.
     # fixme - uses coordinates to decide which mapping is better.
     #  - Improve: use dihedral angles to decide which mapping is better too
     def item_or_list(suptops):
@@ -349,7 +342,8 @@ def extract_best_suptop(suptops, ignore_coords, weights, get_list=False):
 
         return (mcs_score + rmsd_score) / len(weights)
 
-    different_length_suptops.sort(key=score)
+    if use_combined_score:
+        different_length_suptops.sort(key=score)
     # if they have a different length, there must be a reason why it is better.
     # todo
 

--- a/ties/overlay.py
+++ b/ties/overlay.py
@@ -17,10 +17,10 @@ def _overlay(
     parent_n2,
     bond_types,
     suptop,
-    ignore_coords=False,
+    use_rmsd=True,
     use_element_type=True,
     exact_coords_cue=False,
-    weights=(1, 0.01),
+    weights=None,
 ):
     """
     Jointly and recursively traverse the molecule while building up the suptop.
@@ -176,7 +176,7 @@ def _overlay(
             parent_n2=n2,
             bond_types=(n1_bond.type, n2_bond.type),
             suptop=suptop,
-            ignore_coords=ignore_coords,
+            use_rmsd=use_rmsd,
             use_element_type=use_element_type,
             exact_coords_cue=exact_coords_cue,
             weights=weights,
@@ -214,7 +214,7 @@ def _overlay(
             if sol2 in all_solutions:
                 all_solutions.remove(sol2)
 
-    best_suptop = extract_best_suptop(all_solutions, ignore_coords, weights=weights)
+    best_suptop = extract_best_suptop(all_solutions, use_rmsd, weights=weights)
     return best_suptop
 
 
@@ -274,18 +274,17 @@ def merge_compatible_suptops_faster(pairing_suptop: dict, min_bonds: int):
     return built_topologies
 
 
-def extract_best_suptop(
-    suptops, ignore_coords, weights, use_combined_score=False, get_list=False
-):
+def extract_best_suptop(suptops, use_rmsd=True, weights=None, get_list=False):
     """
     Assumes that any merging possible already took place.
     We now have a set of solutions and have to select the best ones.
 
     :param suptops:
-    :param ignore_coords: Do not use coordinates at all. This means a very simple selection
-        based purely on the MCS size.
-    :param use_combined_score: Whether to use a combined score (MCS size with RMSD) for an
+    :param use_rmsd: use RMSD to decide which SupTop is better when they are the same length.
+        Ie use the MCS size only.
+    :param weights: Weights (tuple[]) in a combined score (MCS size with RMSD) for an
         automated selection. Note this feature was causing tricky issues.
+        None means it is not used
     :return:
     """
 
@@ -309,27 +308,30 @@ def extract_best_suptop(
     # sort from largest to smallest
     suptops.sort(key=lambda st: len(st), reverse=True)
 
-    if ignore_coords:
+    if not use_rmsd:
         return item_or_list(suptops)
 
     # when length is the same, take the smaller RMSD
     # most likely this is about hydrogens
-    different_length_suptops = []
+    length_rmsd_sorted_suptops = []
     for key, same_length_suptops in itertools.groupby(suptops, key=lambda st: len(st)):
         # order by RMSD
         sorted_by_rmsd = sorted(
-            same_length_suptops,
-            key=lambda st: st.align_ligands_using_mcs(),
-            reverse=True,
+            same_length_suptops, key=lambda st: st.align_ligands_using_mcs()
         )
-        # these have the same lengths and the same RMSD, so they must be mirrors
-        for suptop in sorted_by_rmsd[1:]:
-            if suptop.is_mirror_of(sorted_by_rmsd[0]):
-                sorted_by_rmsd[0].add_mirror_suptop(suptop)
+
+        best_rmsd_suptop = sorted_by_rmsd[0]
+
+        # add the best RMSD solution first
+        length_rmsd_sorted_suptops.append(best_rmsd_suptop)
+
+        # compare the best RMSD suptop with others
+        for next_suptop in sorted_by_rmsd[1:]:
+            if next_suptop.is_mirror_of(best_rmsd_suptop):
+                best_rmsd_suptop.add_mirror_suptop(next_suptop)
             else:
-                # add it as a different solution
-                different_length_suptops.append(suptop)
-        different_length_suptops.append(sorted_by_rmsd[0])
+                # alternative solution
+                length_rmsd_sorted_suptops.append(next_suptop)
 
     # sort using weights
     # score = mcs_score * weight - rmsd * weight ;
@@ -342,12 +344,10 @@ def extract_best_suptop(
 
         return (mcs_score + rmsd_score) / len(weights)
 
-    if use_combined_score:
-        different_length_suptops.sort(key=score)
-    # if they have a different length, there must be a reason why it is better.
-    # todo
+    if weights:
+        length_rmsd_sorted_suptops.sort(key=score)
 
-    return item_or_list(different_length_suptops)
+    return item_or_list(length_rmsd_sorted_suptops)
 
 
 def are_consistent_topologies(suptops: list["SuperimposedTopology"]):  # noqa: F821

--- a/ties/overlay.py
+++ b/ties/overlay.py
@@ -325,7 +325,9 @@ def extract_best_suptop(suptops, ignore_coords, weights, get_list=False):
     for key, same_length_suptops in itertools.groupby(suptops, key=lambda st: len(st)):
         # order by RMSD
         sorted_by_rmsd = sorted(
-            same_length_suptops, key=lambda st: st.align_ligands_using_mcs()
+            same_length_suptops,
+            key=lambda st: st.align_ligands_using_mcs(),
+            reverse=True,
         )
         # these have the same lengths and the same RMSD, so they must be mirrors
         for suptop in sorted_by_rmsd[1:]:

--- a/ties/pair.py
+++ b/ties/pair.py
@@ -156,7 +156,7 @@ class Pair:
             redistribute_charges_over_unmatched=self.config.redistribute_q_over_unmatched,
             ignore_charges_completely=self.config.ignore_charges_completely,
             ignore_bond_types=True,
-            ignore_coords=False,
+            ignore_coords=self.config.ignore_coords,
             partial_rings_allowed=self.config.partial_ring_allowed,
             align_molecules=self.config.align_molecules_using_mcs,
             use_general_type=self.config.use_element_in_superimposition,

--- a/ties/pair.py
+++ b/ties/pair.py
@@ -156,7 +156,7 @@ class Pair:
             redistribute_charges_over_unmatched=self.config.redistribute_q_over_unmatched,
             ignore_charges_completely=self.config.ignore_charges_completely,
             ignore_bond_types=True,
-            ignore_coords=self.config.ignore_coords,
+            use_rmsd=self.config.use_rmsd,
             partial_rings_allowed=self.config.partial_ring_allowed,
             align_molecules=self.config.align_molecules_using_mcs,
             use_general_type=self.config.use_element_in_superimposition,

--- a/ties/testing/test_overlayer.py
+++ b/ties/testing/test_overlayer.py
@@ -117,14 +117,20 @@ def test_SimpleMultipleSolutions_rightStart(CNO_O):
     assert len(suptop.mirrors) == 1
     worse_st = suptop.mirrors[0]
 
-    # check if both representations were found
-    # The ester allows for mapping (O1-O11, O2-O12) and (O1-O12, O2-O11)
-    assert suptop.contains_atom_name_pair(
-        "O1", "O1"
-    ) and suptop.contains_atom_name_pair("O2", "O2")
-    assert worse_st.contains_atom_name_pair(
-        "O1", "O2"
-    ) and worse_st.contains_atom_name_pair("O2", "O1")
+    case_1_found = False
+    case_2_found = False
+    for st in (suptop, worse_st):
+        # check if both representations were found
+        # The ester allows for mapping (O1-O11, O2-O12) and (O1-O12, O2-O11)
+        case_1_found = worse_st.contains_atom_name_pair(
+            "O1", "O1"
+        ) and worse_st.contains_atom_name_pair("O2", "O2")
+        case_2_found = suptop.contains_atom_name_pair(
+            "O1", "O2"
+        ) and suptop.contains_atom_name_pair("O2", "O1")
+
+    assert case_1_found
+    assert case_2_found
 
     assert suptop.contains_atom_name_pair("C1", "C1")
     assert suptop.contains_atom_name_pair("N1", "N1")

--- a/ties/testing/test_overlayer.py
+++ b/ties/testing/test_overlayer.py
@@ -370,7 +370,6 @@ def test_3C_circle(CCC):
         parent_n2=None,
         bond_types=(None, None),
         suptop=SuperimposedTopology(CCC, CCC2),
-        ignore_coords=False,
     )
     # there is one symmetrical way to traverse it
     assert len(suptop.mirrors) == 1

--- a/ties/testing/test_overlayer.py
+++ b/ties/testing/test_overlayer.py
@@ -226,12 +226,12 @@ def test_Many2One_part2(CN_N, CN):
 
 def test_MultipleSolutions2Levels_rightStart(CN_N):
     """
-         LIGAND 1        LIGAND 2
-            C1              C11
-            /\              / \
-         N1    N2        N11   N12
-            / \    / \      /  \   /  \
-       O1 O2  O3 O4   O11 O12 O13 O14
+         LIGAND 1 & 2
+            C1
+            /\
+         N1    N2
+        / \    / \
+       O1 O2  O3 O4
     """
     c1, n1, n2 = CN_N
 
@@ -260,17 +260,17 @@ def test_MultipleSolutions2Levels_rightStart(CN_N):
         suptop=SuperimposedTopology(pyramid_left, pyramid_right),
     )
 
-    correct_overlaps = [
-        ("C1", "C1"),
-        ("N1", "N1"),
-        ("N2", "N2"),
-        ("O1", "O1"),
-        ("O2", "O2"),
-        ("O3", "O3"),
-        ("O4", "O4"),
+    an_overlap = [
+        ("C", "C"),
+        ("N", "N"),
+        ("N", "N"),
+        ("O", "O"),
+        ("O", "O"),
+        ("O", "O"),
+        ("O", "O"),
     ]
-    for atomName1, atomName2 in correct_overlaps:
-        assert suptop.contains_atom_name_pair(atomName1, atomName2)
+    for (node1, node2), (element1, element2) in zip(suptop.matched_pairs, an_overlap):
+        assert node1.element == element1 and node2.element == element2
 
 
 def test_2sameAtoms_2Cs_symmetry(CC):

--- a/ties/testing/test_overlayer.py
+++ b/ties/testing/test_overlayer.py
@@ -117,20 +117,14 @@ def test_SimpleMultipleSolutions_rightStart(CNO_O):
     assert len(suptop.mirrors) == 1
     worse_st = suptop.mirrors[0]
 
-    case_1_found = False
-    case_2_found = False
-    for st in (suptop, worse_st):
-        # check if both representations were found
-        # The ester allows for mapping (O1-O11, O2-O12) and (O1-O12, O2-O11)
-        case_1_found = worse_st.contains_atom_name_pair(
-            "O1", "O1"
-        ) and worse_st.contains_atom_name_pair("O2", "O2")
-        case_2_found = suptop.contains_atom_name_pair(
-            "O1", "O2"
-        ) and suptop.contains_atom_name_pair("O2", "O1")
-
-    assert case_1_found
-    assert case_2_found
+    # check if both representations were found
+    # The ester allows for mapping (O1-O11, O2-O12) and (O1-O12, O2-O11)
+    assert suptop.contains_atom_name_pair(
+        "O1", "O1"
+    ) and suptop.contains_atom_name_pair("O2", "O2")
+    assert worse_st.contains_atom_name_pair(
+        "O1", "O2"
+    ) and worse_st.contains_atom_name_pair("O2", "O1")
 
     assert suptop.contains_atom_name_pair("C1", "C1")
     assert suptop.contains_atom_name_pair("N1", "N1")
@@ -376,6 +370,7 @@ def test_3C_circle(CCC):
         parent_n2=None,
         bond_types=(None, None),
         suptop=SuperimposedTopology(CCC, CCC2),
+        ignore_coords=False,
     )
     # there is one symmetrical way to traverse it
     assert len(suptop.mirrors) == 1

--- a/ties/testing/test_superimpose_api.py
+++ b/ties/testing/test_superimpose_api.py
@@ -43,6 +43,6 @@ def test_rmsd_suptop(data):
     # calculate the benzene/oxygen ring of the superimposed area
     # this is done without the superimposition
     rmsd = suptop.rmsd()
-    np.testing.assert_allclose(rmsd, 3.3815635)
+    np.testing.assert_allclose(rmsd, 3.381564)
     aligned_rmsd = suptop.align_ligands_using_mcs()
     np.testing.assert_allclose(aligned_rmsd, 0.05504, rtol=1e05)

--- a/ties/testing/test_user_topology_superimposer.py
+++ b/ties/testing/test_user_topology_superimposer.py
@@ -610,8 +610,7 @@ def test_filter_net_charge_too_large():
     Therefore, remove the pair that has the highest
     charge difference, which is N1-N11
 
-    Ligand 1
-
+    Ligand 1:
          C1 - C2 (+0.07e)
          /      \
     Cl1-C3      C4
@@ -623,9 +622,7 @@ def test_filter_net_charge_too_large():
              C8 (-0.03e)
              |
              C9
-
-
-    Ligand 2
+    Ligand 2:
                  Cl11
                 /
          C11 - C12 (-0.07e)
@@ -722,7 +719,11 @@ def test_filter_net_charge_too_large():
 
     # we have to discriminate against this case somehow
     suptop = superimpose_topologies(
-        top1_list, top2_list, align_molecules=False, partial_rings_allowed=True
+        top1_list,
+        top2_list,
+        align_molecules=False,
+        partial_rings_allowed=True,
+        starting_pair_seed=[("C2", "C12")],
     )
     # removed because the charge difference was too large
     assert not suptop.contains_atom_name_pair("C2", "C12")


### PR DESCRIPTION
The RMSD was turned off after the issues with a combined score (suptop length and RMSD). Here we are bringing it back in a basic way to help order suptops when they have the same length.

