### PR TITLE
Add indices for the basic ligand map

### DIFF
--- a/ties/ligand.py
+++ b/ties/ligand.py
@@ -71,6 +71,11 @@ class Ligand:
         self._renaming_map = None
         self.ligand_with_uniq_atom_names = None
 
+        self.index: int | None = None
+
+    def set_index(self, index: int):
+        self.index = index
+
     def __repr__(self):
         # return self.original_input.stem
         return self.internal_name

--- a/ties/ligandmap.py
+++ b/ties/ligandmap.py
@@ -32,6 +32,10 @@ class LigandMap:
         self.map_weights = None
         self.graph = None
 
+        # assign indices to the ligands
+        for i, lig in enumerate(self.ligands):
+            lig.index = i
+
     def generate_map(self):
         """
         Use the underlying morphs to extract the each to each cases.


### PR DESCRIPTION
The basic ligand map requires indices. Since the indices are not used anywhere else, we set them in the LigandMap. 